### PR TITLE
Add admin mgmt and site activation methods

### DIFF
--- a/app/controllers/v1/ministries_controller.rb
+++ b/app/controllers/v1/ministries_controller.rb
@@ -9,6 +9,13 @@ module V1
       render_ministries
     end
 
+    def update
+      ministry = Ministry.find_by(min_code: params[:id])
+      render status: 404, json: { error: "Ministry not found for country code #{ params[:id] } " } and return if ministry.nil?
+      ministry.activate_site
+      render status: 200, json: { success: "Ministry site activated for #{ ministry.name }" }
+    end
+
     private
 
     def filter_ministries

--- a/app/controllers/v1/user_roles_controller.rb
+++ b/app/controllers/v1/user_roles_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module V1
+  class UserRolesController < BaseController
+    before_action :authenticate_request
+
+    def create
+      @ministry = Ministry.find_by(min_code: params[:ministry])
+      render_error_not_found and return if @ministry.nil?
+      add_default_admins and return if params[:admin].downcase == 'default'
+      add_admin
+    end
+
+    private
+
+    def add_admin
+      admin = @ministry.add_admin(params[:admin])
+      render status: 200, json: {success: success_message(admin)}
+    end
+
+    def add_default_admins
+      @ministry.add_default_admins
+      render status: 200, json: { success: "Added default admins" }
+    end
+
+    def render_error_not_found
+      render status: 404, json: {error: "Ministry '#{ params[:ministry] }' not found"}
+    end
+
+    def success_message(admin)
+      action_message = admin.nil? ? "Admin already exists for" : "added as admin to"
+      return_message = "#{ admin&.person&.first_name } #{ admin&.person&.last_name } #{ action_message } #{@ministry.min_code}"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,9 @@ Rails.application.routes.draw do
   api_version(module: 'V1', path: { value: 'v1' }) do
     resources :countries, only: [:index]
     resources :languages, only: [:index]
-    resources :ministries, only: [:index]
+    resources :ministries, only: [:index, :update]
     resources :people, only: [:index, :show, :create, :update, :destroy]
     resource :user, only: [:show]
+    resource :user_roles, only: [:create]
   end
 end


### PR DESCRIPTION
This PR introduces the following **new** endpoints:

* `PUT /ministry/:min_code` - Activate the SPA site for the given ministry (supply 3-letter min_code). In addition to generating and saving a Global Registry API key, this method will additionally add all default admins to be site admins for the newly activated ministry site.
* `POST /user_roles` - Add an admin to a specific ministry's SPA site by email or guid. Parameters:
  * `admin` (required) - The Key GUID or email for the person to be credentialed as admin
  * `ministry` (required) - The three letter min code for the ministry to which the admin should be added.